### PR TITLE
Rename wget.py to curl.py in the usage message too

### DIFF
--- a/examples/curl.py
+++ b/examples/curl.py
@@ -59,7 +59,7 @@ def get_mac_address(ifname):
 
 
 def print_usage():
-    print """USAGE: sudo python wget.py 192.168.4.4 example.com [interface]
+    print """USAGE: sudo python curl.py 192.168.4.4 example.com [interface]
 
 The IP address you specify should be
 - on the same subnet as you and


### PR DESCRIPTION
When `wget.py` was renamed `curl.py` the usage message wasn't updated accordingly. This is a very minor edit but hopefully it's correct.
